### PR TITLE
Display messages

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,15 +1,39 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS (and SCSS, if configured) file within this directory, lib/assets/stylesheets, or any plugin's
- * vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require_tree .
- *= require_self
- */
+.flash {
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+}
+
+.notice {
+  background-color: #dff0d8;
+  color: #3c763d;
+  border: 1px solid #d6e9c6;
+}
+
+.alert {
+  background-color: #f2dede;
+  color: #a94442;
+  border: 1px solid #ebccd1;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  float: right;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.error-messages {
+  background-color: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+  padding: 10px;
+  margin-bottom: 15px;
+  border-radius: 5px;
+  list-style-type: none;
+}
+
+.error-messages li {
+  margin: 5px 0;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
   helper_method :current_user
   before_action :set_locale
 
@@ -16,5 +17,13 @@ class ApplicationController < ActionController::Base
 
   def authenticate_user!
     redirect_to login_path unless current_user
+  end
+
+  private
+
+  def not_found
+    render file: Rails.public_path.join('404.html'),
+           status: :not_found,
+           layout: false
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,10 +21,15 @@ class UsersController < ApplicationController
     @user = current_user
 
     if @user.authenticate(params[:user][:current_password])
-      if @user.update(user_params)
-        redirect_to root_path, notice: t('users.password.update_success')
+      if passwords_present?
+        if @user.update(user_params)
+          redirect_to root_path, notice: t('users.password.update_success')
+        else
+          flash.now[:alert] = t('users.password.update_failed')
+          render :edit
+        end
       else
-        flash.now[:alert] = t('users.password.update_failed')
+        flash.now[:alert] = t('users.password.fields_cannot_be_blank')
         render :edit
       end
     else
@@ -37,5 +42,9 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:email, :password, :password_confirmation)
+  end
+
+  def passwords_present?
+    params[:user][:password].present? && params[:user][:password_confirmation].present?
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -8,6 +8,7 @@ class Task < ApplicationRecord
   enum status: { pending: 1, in_progress: 2, completed: 3 }
 
   validates :title, presence: true
+  validates :content, presence: true
   validates :priority, presence: true
   validates :status, presence: true
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
 
   <body>
     <%= render 'shared/navbar' %>
+    <%= render "shared/flash" if flash.any? %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,8 @@
+<% [:notice, :alert].each do |type| %>
+  <% if flash[type] %>
+    <div class="flash <%= type %>">
+      <%= flash[type] %>
+      <button onclick="this.parentElement.style.display='none'" class="close-btn">X</button>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,3 +1,13 @@
+<% if @task.errors.any? %>
+  <section class="error-messages">
+    <ul>
+    <% @task.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+    </ul>
+  </section>
+<% end %>
+
 <%= form_with model: @task, local: true do |form| %>
   <div>
     <%= form.label :title, t('tasks.form.title') %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,6 +1,17 @@
 <h1><%= t('users.headers.update_password') %></h1>
 
-<%= form_with model: @user, url: user_path(@user), method: :patch, local: true do |form| %>
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h2>
+    <ul>
+      <% @user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= form_with model: @user, url: user_path(@user), method: :patch, local: true, data: { turbo: false } do |form| %>
   <div>
     <%= form.label :current_password, t('users.form.current_password') %>
     <%= form.password_field :current_password %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,15 @@
 <h1><%= t('users.headers.registration') %></h1>
 
+<% if @user.errors.any? %>
+  <section class="error-messages">
+    <ul>
+    <% @user.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+    </ul>
+  </section>
+<% end %>
+
 <%= form_with model: @user, url: signup_path, local: true do |form| %>
   <div>
     <%= form.label :email, t('users.form.email') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,8 @@ en:
       success: "Registration successful, you are now logged in"
     password:
       update_success: "Password successfully updated"
+      current_password_incorrect: "Current password is incorrect"
+      fields_cannot_be_blank: "Password and password confirmation cannot be blank"
     headers:
       registration: "Sign Up"
       update_password: "Change Password"
@@ -181,3 +183,12 @@ en:
         email: "Email"
         role: "Role"
         submit: "Submit"
+  activerecord:
+    errors:
+      models:
+        task:
+          attributes:
+            title:
+              blank: "can't be blank"
+            content:
+              blank: "can't be blank"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -136,6 +136,8 @@ zh-TW:
       success: "註冊成功，您已登入"
     password:
       update_success: "密碼已成功更新"
+      current_password_incorrect: "當前密碼不正確"
+      fields_cannot_be_blank: "密碼和確認密碼不能為空"
     headers:
       registration: '註冊'
       update_password: '更改密碼'
@@ -190,4 +192,12 @@ zh-TW:
         email: "電子郵件"
         role: "角色"
         submit: "提交"
-
+  activerecord:
+    errors:
+      models:
+        task:
+          attributes:
+            title:
+              blank: "標題不能為空"
+            content:
+              blank: "內容不能為空"


### PR DESCRIPTION
This pull request introduces improvements to error handling, message display, and internationalization in the user interface. Specifically, it adds support for redirecting to a 404 page in certain error scenarios, enhances the display of alert and notice messages, and integrates these messages with the I18n system for multilingual support.

#### Changes Introduced
1. Set NotFound Status Redirect to Public 404 Page

2. Added basic CSS to display flash messages, including alerts and notices.

 - Ensures that users can see relevant messages immediately after successful or failed operations.
3. Added Messages to I18n

 - Integrated various messages (e.g., password error prompts) into the I18n system to support multilingual display.